### PR TITLE
fix build on v1.2

### DIFF
--- a/nimpb/json.nim
+++ b/nimpb/json.nim
@@ -16,7 +16,7 @@ proc `%`*(u: uint32): JsonNode =
     newJFloat(float(u))
 
 proc `%`*(b: seq[byte]): JsonNode =
-    result = newJString(base64.encode(cast[string](b), newLine=""))
+    result = newJString(base64.encode(cast[string](b)))
 
 proc toJson*(value: float): JsonNode =
     case classify(value)


### PR DESCRIPTION
This change seems to be necessary to build on v1.2. We can build both v1.0 and v1.2.

v1.2 does not have `newLine` parameter for the encode function. Since the original passed empty string for newLine parameter, I assume it is good enough to remove it. Please let me know, if you have any comments.